### PR TITLE
Fix signature/deliveryId header fields to LC

### DIFF
--- a/src/hubot-github-webhook-listener.coffee
+++ b/src/hubot-github-webhook-listener.coffee
@@ -52,8 +52,8 @@ module.exports = (robot) ->
         robot.logger.info("Github post received: ", req)
       eventBody =
         eventType   : req.headers["x-github-event"]
-        signature   : req.headers["X-Hub-Signature"]
-        deliveryId  : req.headers["X-Github-Delivery"]
+        signature   : req.headers["x-hub-signature"]
+        deliveryId  : req.headers["x-github-delivery"]
         payload     : req.body
         query       : querystring.parse(url.parse(req.url).query)
 


### PR DESCRIPTION
Hubot does not seem to like the case sensitive "X-Hub-Signature" or "X-Github-Delivery" header fields. Making them lowercase seems to fix the issue. This PR is in relation to #1.
